### PR TITLE
Exit 1 when gpg fails in multiline too.

### DIFF
--- a/src/password-store.sh
+++ b/src/password-store.sh
@@ -378,7 +378,7 @@ cmd_insert() {
 	if [[ $multiline -eq 1 ]]; then
 		echo "Enter contents of $path and press Ctrl+D when finished:"
 		echo
-		$GPG -e "${GPG_RECIPIENT_ARGS[@]}" -o "$passfile" "${GPG_OPTS[@]}"
+		$GPG -e "${GPG_RECIPIENT_ARGS[@]}" -o "$passfile" "${GPG_OPTS[@]}" || exit 1
 	elif [[ $noecho -eq 1 ]]; then
 		local password password_again
 		while true; do


### PR DESCRIPTION
Multiline insert errors incorrectly gave a exit code of 0, now correctly propagated.

This leads to problems when for example using a GPG smart-card and not having it inserted at time of requesting a password.

The problem becomes apparent when using pass as part of automation (puppet, ansible etc) or with a wrapper, for example https://github.com/IJHack/qtpass/issues/18