### PR TITLE
passmenu: Add option to notify-send after copying password

### DIFF
--- a/contrib/dmenu/passmenu
+++ b/contrib/dmenu/passmenu
@@ -5,11 +5,13 @@ shopt -s nullglob globstar
 PROGRAM="${0##*/}"
 
 typeit=0
+notify=0
 
-opts="$(getopt -o "" -l typeit -n "$PROGRAM" -- "$@")"
-[[ $? -ne 0 ]] && (echo "Usage: $PROGRAM [--typeit]" >&2 ; exit 1)
+opts="$(getopt -o "" -l notify,typeit -n "$PROGRAM" -- "$@")"
+[[ $? -ne 0 ]] && (echo "Usage: $PROGRAM [--notify] [--typeit]" >&2 ; exit 1)
 eval set -- "$opts"
 while true; do case $1 in
+	--notify) notify=1; shift ;;
 	--typeit) typeit=1; shift ;;
 	--) shift; break ;;
 esac done
@@ -24,6 +26,12 @@ password=$(printf '%s\n' "${password_files[@]}" | dmenu "$@")
 [[ -n $password ]] || exit
 
 if [[ $typeit -eq 0 ]]; then
+	if [[ $notify -ne 0 ]] && hash notify-send; then
+		PASSWORD_STORE_POST_COPY_HOOK() {
+			notify-send -a "${PROGRAM}" -u normal -t 2000 "Copied $1" "$2"
+		}
+		export -f PASSWORD_STORE_POST_COPY_HOOK
+	fi
 	pass show -c "$password" 2>/dev/null
 else
 	pass show "$password" |

--- a/contrib/dmenu/passmenu
+++ b/contrib/dmenu/passmenu
@@ -2,11 +2,17 @@
 
 shopt -s nullglob globstar
 
+PROGRAM="${0##*/}"
+
 typeit=0
-if [[ $1 == "--type" ]]; then
-	typeit=1
-	shift
-fi
+
+opts="$(getopt -o "" -l typeit -n "$PROGRAM" -- "$@")"
+[[ $? -ne 0 ]] && (echo "Usage: $PROGRAM [--typeit]" >&2 ; exit 1)
+eval set -- "$opts"
+while true; do case $1 in
+	--typeit) typeit=1; shift ;;
+	--) shift; break ;;
+esac done
 
 prefix=${PASSWORD_STORE_DIR-~/.password-store}
 password_files=( "$prefix"/**/*.gpg )

--- a/src/password-store.sh
+++ b/src/password-store.sh
@@ -119,6 +119,10 @@ check_sneaky_paths() {
 	done
 }
 
+function_exists() {
+	type $1 >/dev/null && [[ "$(type -t $1)" -eq "function" ]]
+}
+
 #
 # END helper functions
 #
@@ -151,7 +155,13 @@ clip() {
 
 		echo "$before" | base64 -d | xclip -selection "$X_SELECTION"
 	) 2>/dev/null & disown
-	echo "Copied $2 to clipboard. Will clear in $CLIP_TIME seconds."
+
+	local copied_message="Copied $2 to clipboard. Will clear in $CLIP_TIME seconds."
+	echo "$copied_message"
+
+	if function_exists 'PASSWORD_STORE_POST_COPY_HOOK'; then
+		PASSWORD_STORE_POST_COPY_HOOK "$2" "$copied_message"
+	fi
 }
 tmpdir() {
 	[[ -n $SECURE_TMPDIR ]] && return


### PR DESCRIPTION
With these changes, passmenu can provide visual feedback confirming that the password has been successfully copied to the cliboard. This is useful for example if using passmenu on a weak laptop where the "gpg-askpass, unlock keyring, decrypt password file, copy to clipboard" procedure can take a few seconds to complete.

Summary of changes:

 - `pass show --clip` now checks to see if the shell function `PASSWORD_STORE_POST_COPY_HOOK` is present. If it is, it is called with two arguments:
    1. The name of the copied password (`foo/bar` if pass is invoked as `pass show -c foo/bar`)
    2. The `"Copied $2 to clipboard. Will clear in $CLIP_TIME" seconds.` message, which is also printed to the console

   This callback can be supplied for example by exporting it with `export -f` from a parent shell. This should not be a security vulnerability since anything that can successfully invoke `pass -c` can also get passwords in plaintext with a plain `pass show`, but please let me know if I overlooked something obvious in this design decision.
 - passmenu now accepts the `--notify` command line option. If `--notify` is specified and `--typeit` is not, then a desktop notification will be shown using `notify-send` after pass has copied the password to the clipboard.

Comments and critique are welcome!